### PR TITLE
Day9

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,36 @@ Today we focused on ([→ Full Details](logs/Day8.md)):
 - Global toast system with `sonner`
 - Graceful error handling + proper Authorization header
 
+# 📘 SkillMate – Day 9: Backend Testing Begins 🧪
+
+Today we introduced backend testing using **pytest** with an isolated in-memory SQLite database. Our main goal was to set up a clean testing structure and validate our first endpoint: `GET /api/skills`.
+
+---
+
+## ✅ Accomplishments
+
+- ✅ Set up **pytest** for the FastAPI backend
+- ✅ Created a test-only in-memory SQLite DB
+- ✅ Built `tests/conftest.py` with test client and fixtures
+- ✅ Added a `seed_test_db()` to populate skill levels and skills
+- ✅ Wrote and passed our **first test** for `GET /api/skills`
+- ✅ Learned how to override dependencies using FastAPI’s `app.dependency_overrides`
+
+---
+
+## 🏗️ New Files and Structure
+tests/
+├── conftest.py # Pytest fixtures: DB setup, dependency override
+├── test_skills.py # GET /api/skills test
+└── utils/
+└── seed.py # Seed function to insert test skills
+
+## 🔧 `tests/conftest.py`
+
+- Creates in-memory SQLite DB
+- Overrides production DB dependency
+- Seeds skills + levels
+- Drops schema after all tests complete
 
 ## 📅 Daily Goal
 

--- a/README.md
+++ b/README.md
@@ -206,40 +206,15 @@ SkillMate is a full-stack platform to help users manage, showcase, and track the
 🔥 **Reflection**: This was a real engineer's day. You cleaned architecture, handled DB relations like a pro, solved real-world bugs, and built solid auth. You're not just building apps now — you're building systems.
 # 📅 Day 8 – UX Polish, Auth Routing, Error Handling, Toast System
 
-Today we focused on:
-- Securing routes with `AuthLayout`
-- Enhancing the `AddSkill` form UX
-- Gracefully handling API errors
-- Setting up a global toast system with proper structure
-
----
-
-## ✅ 1. Auth Protection via Layout (TanStack Router)
-
-- Created `AuthLayout.tsx` to wrap all protected routes.
-- Created `PublicLayout.tsx` to wrap public routes like `/login` and `/register`.
-- Used `beforeLoad` to redirect:
-  - ✅ Guests → from protected routes to `/login`
-  - ✅ Authenticated users → from `/login` to `/`
-- Example:
-
-```tsx
-{
-  element: <AuthLayout />,
-  beforeLoad: () => {
-    if (!useAuthStore.getState().token) throw redirect({ to: "/login" });
-  },
-  children: [
-    {
-      path: "/",
-      element: <HomePage />,
-    },
-    {
-      path: "/add-skill",
-      element: <AddSkillPage />,
-    },
-  ],
-}
+Today we focused on ([→ Full Details](logs/Day8.md)):
+- Protected routing with `beforeLoad` and TanStack Router
+- Public vs Auth layouts
+- SSR-safe localStorage access
+- Improved login flow (via `performLogin` in Zustand)
+- Fixed auth state sync issues (read from localStorage)
+- AddSkillPage UX polish (validation, loading, reset)
+- Global toast system with `sonner`
+- Graceful error handling + proper Authorization header
 
 
 ## 📅 Daily Goal

--- a/backend/controllers/skill_controller.py
+++ b/backend/controllers/skill_controller.py
@@ -34,8 +34,9 @@ def get_skills(db:Session) -> list[SkillRead] :
              ]
           return results
      except Exception as e:
-          raise HTTPException(status_code=500,detail="Something went Wrong")
-     
+        # import traceback
+        # traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))     
 
 def add_skills(skill:SkillIn, db:Session) -> SkillRead : #the -> symbol in a function definition is used for type hints, specifically to indicate the return type of the function
     # check_duplicate_skill_name(skill.name)

--- a/backend/data/db.py
+++ b/backend/data/db.py
@@ -42,5 +42,5 @@ def get_session() -> Generator[Session, None, None]:
         Purpose: You would call this function once when your application starts up for the first time, or during a setup script, to create all the necessary tables in your skillmate.db file.
 
  """
-def init_db()->None :
+def init_db() ->None :
     SQLModel.metadata.create_all(engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,11 +3,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from middlewares.logging import LoggingMiddleware
 from routes.index import router
 from data.db import init_db
+import logging
 
 app = FastAPI( title="SkillMate API",
     description="API for SkillMate application",
     version="0.1.0")
-
+logging.basicConfig(level=logging.DEBUG)
 # Event handler to initialize the database on application startup
 @app.on_event("startup")
 def on_startup():

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, Session, create_engine
+from main import app
+from data.db import get_session
+from tests.utils.seed import seed_test_db
+from sqlalchemy.pool import StaticPool
+
+# In-memory SQLite for testing
+DATABASE_URL = "sqlite:///:memory:"
+test_db_engine = create_engine(DATABASE_URL, connect_args = {"check_same_thread":False},    poolclass=StaticPool)
+
+# Dependency override for FastAPI
+def override_get_session():
+    with Session(test_db_engine) as session:
+        yield session
+# Apply the override globally
+app.dependency_overrides[get_session] = override_get_session
+
+# Create schema and seed DB before running tests
+@pytest.fixture(scope="session", autouse=True)
+def prepare_test_db():
+    SQLModel.metadata.create_all(test_db_engine)
+    with Session(test_db_engine) as session:
+        seed_test_db(session)  # ✅ Use real seeded skills with skill levels
+    yield
+    SQLModel.metadata.drop_all(test_db_engine)
+
+# Provide test client
+
+@pytest.fixture
+def client():
+    return TestClient(app)

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1,0 +1,5 @@
+def test_get_skills(client):
+    res = client.get("/api/skills/")
+    print("RESPONSE TEXT:", res.text)  # print raw error message
+    assert res.status_code == 200
+    assert isinstance(res.json(),list)

--- a/backend/tests/utils/seed.py
+++ b/backend/tests/utils/seed.py
@@ -1,0 +1,18 @@
+from sqlmodel import Session
+from models.skill import Skill
+from models.skill_level import SkillLevel
+
+def seed_test_db(db_con:Session):
+    beginner = SkillLevel(name="Beginner",description="Just Starting")
+    intermediate = SkillLevel(name="Intermediate",description="Going Good")
+    advance = SkillLevel(name="Advance",description="Master")
+
+    db_con.add_all([beginner,intermediate,advance])
+    db_con.flush() # Get generated IDs
+
+    skill_php = Skill(name="PHP",skill_level_id=advance.id)
+    skill_py = Skill(name="Python",skill_level_id=beginner.id)
+    skill_js = Skill(name="JavaScript",skill_level_id=intermediate.id)
+
+    db_con.add_all([skill_php,skill_js,skill_py])
+    db_con.commit()

--- a/logs/day8.md
+++ b/logs/day8.md
@@ -1,0 +1,142 @@
+# 🗕️ Day 8 – Protected Routing, Toasts, and Error Handling
+
+---
+
+## 🔐 Authentication & Routing with TanStack Router
+
+### ✅ Public vs Authenticated Layouts
+
+* Introduced `PublicLayout.tsx` and `AuthLayout.tsx` (default layout for logged-in users).
+* Ensured routing logic is clean and role-aware.
+
+### 🔒 `beforeLoad` Auth Guard
+
+* Used `beforeLoad` on `authenticatedLayoutRoute` to protect private routes.
+* Redirects to `/login` if user is not authenticated.
+
+```tsx
+beforeLoad: async () => {
+  const isLoggedIn = useAuthStore.getState().is_loggedin();
+  if (!isLoggedIn) throw redirect({ to: "/login" });
+}
+```
+
+### 🔁 Public Route Redirection
+
+* If already logged in, redirect from `/login` back to `/`.
+
+```tsx
+useEffect(() => {
+  if (is_loggedin()) navigate({ to: "/" });
+}, []);
+```
+
+---
+
+## 🧠 Zustand Auth Store Enhancements
+
+### ✅ SSR-Safe Token Access
+
+* Fixed SSR error by guarding `localStorage` reads:
+
+```ts
+const is_loggedin = () => {
+  if (typeof window === "undefined") return false;
+  return !!localStorage.getItem("token");
+};
+```
+
+### ✅ Centralized Login Handling
+
+* Moved login logic inside `performLogin()` action in `useAuthStore`.
+
+```ts
+performLogin: async (user) => {
+  const response = await loginUser(user);
+  setAuth(response); // sync to store + localStorage
+},
+```
+
+---
+
+## 🧪 AddSkillPage UX Polishing
+
+### ✅ Skill Submission Enhancements
+
+* Added loading state, reset after submit, and input validation.
+
+```tsx
+if (!name.trim()) return setError("Skill name required");
+setIsSubmitting(true);
+await addSkill({ name, level });
+resetForm();
+```
+
+### ✅ Better Error Messages & API Handling
+
+* Improved API error parsing:
+
+```ts
+const err_data = await response.json();
+const err_message = err_data?.detail?.message || "Something went wrong";
+set({ error: err_message });
+throw new Error(response.status === 409 ? "Skill Already Exists" : err_message);
+```
+
+---
+
+## 🔔 Toast Notifications (via `sonner`)
+
+### ✅ Installed and configured sonner
+
+```bash
+npm install sonner
+```
+
+### ✅ Added `<Toaster />` globally
+
+* In `main.tsx`:
+
+```tsx
+import { Toaster } from "@/components/ui/sonner";
+<Toaster richColors position="top-right" />;
+```
+
+OR
+
+* In both layouts: `PublicLayout` and `AuthLayout`.
+
+### ✅ Show Toast on Success/Error
+
+```tsx
+import { toast } from "sonner";
+
+toast.success("Skill added successfully");
+toast.error(error.message || "Failed to add skill");
+```
+
+---
+
+## 🧼 Code Cleanup & Refactors
+
+* Used `useAuthStore.getState().token` instead of raw `localStorage.getItem('token')` in API calls.
+* Introduced default props and boolean prop syntax for testing.
+
+```tsx
+function MyButton({ big = false }: { big?: boolean }) {
+  return <button className={big ? "text-2xl" : "text-sm"}>Click</button>;
+}
+```
+
+---
+
+## ✅ Summary
+
+* Implemented secure routing and redirection with TanStack Router.
+* Polished AddSkillPage UX with better form handling.
+* Global toast notifications with sonner.
+* Robust error parsing from backend.
+* Auth state consistency improved using Zustand.
+* Code cleanup and best practices applied.
+
+---


### PR DESCRIPTION
# 📘 SkillMate – Day 9: Backend Testing Begins 🧪

Today we introduced backend testing using **pytest** with an isolated in-memory SQLite database. Our main goal was to set up a clean testing structure and validate our first endpoint: `GET /api/skills`.

---

## ✅ Accomplishments

- ✅ Set up **pytest** for the FastAPI backend
- ✅ Created a test-only in-memory SQLite DB
- ✅ Built `tests/conftest.py` with test client and fixtures
- ✅ Added a `seed_test_db()` to populate skill levels and skills
- ✅ Wrote and passed our **first test** for `GET /api/skills`
- ✅ Learned how to override dependencies using FastAPI’s `app.dependency_overrides`

---

## 🏗️ New Files and Structure

tests/
├── conftest.py # Pytest fixtures: DB setup, dependency override
├── test_skills.py # GET /api/skills test
└── utils/
└── seed.py # Seed function to insert test skills


---

## 🔧 `tests/conftest.py`

- Creates in-memory SQLite DB
- Overrides production DB dependency
- Seeds skills + levels
- Drops schema after all tests complete

```python
# tests/conftest.py
import pytest
from fastapi.testclient import TestClient
from sqlmodel import SQLModel, Session, create_engine
from main import app
from data.db import get_session
from tests.utils.seed import seed_test_db

DATABASE_URL = "sqlite:///:memory:"
test_db_engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})

def override_get_session():
    with Session(test_db_engine) as session:
        yield session

app.dependency_overrides[get_session] = override_get_session

@pytest.fixture(scope="session", autouse=True)
def prepare_test_db():
    SQLModel.metadata.create_all(test_db_engine)
    with Session(test_db_engine) as session:
        seed_test_db(session)
    yield
    SQLModel.metadata.drop_all(test_db_engine)

@pytest.fixture
def client():
    return TestClient(app)

🧪 tests/test_skills.py

def test_get_skills(client):
    response = client.get("/api/skills/")
    assert response.status_code == 200
    data = response.json()
    assert isinstance(data, list)
    assert len(data) > 0

🪵 Logs & Insights

    Initially got: sqlite3.OperationalError: no such table: skills

    Fixed by ensuring SQLModel.metadata.create_all() runs before seeding

    Used dependency override to point get_session to test DB

    Verified test DB is isolated and auto-cleaned

🧠 Learnings

    FastAPI makes it easy to override dependencies in tests

    In-memory SQLite is fast but must have schema recreated each time

    TestClient is powerful for end-to-end testing of endpoints