### PR TITLE
Day 14 - SkillMate Backend - Docker &  PostgreSQL Setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.env.*
+*.db
+*.sqlite3
+poetry.lock
+tests/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 dist/
 .env
+.env.docker
 
 # Python
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use official Python image
+FROM python:3.11-slim
+
+# Environment config
+#ENV PYTHONDONTWRITEBYTECODE 1 : This sets an environment variable. When set to 1, Python won't write .pyc files (compiled bytecode files) to disk.
+#ENV PYTHONUNBUFFERED 1: This also sets an environment variable. When PYTHONUNBUFFERED is set to 1, Python output (like print() statements or logs) will be sent directly to the terminal without being buffered.
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y build-essential libpq-dev
+
+# Copy dependency files (pyproject, poetry lock, or requirements if exists)
+COPY pyproject.toml poetry.lock* requirements.txt* ./
+
+# Install Python deps
+RUN pip install --upgrade pip && pip install poetry
+RUN poetry config virtualenvs.create false
+RUN poetry install --no-root
+
+# Copy backend source code
+COPY backend ./backend
+
+# # --- ADD THESE DEBUG LINES ---
+# RUN echo "--- Contents of /app/backend/src ---"
+# RUN ls -la /app/backend/src
+
+# RUN echo "--- Contents of /app/backend/src/seeders ---"
+# RUN ls -la /app/backend/src/seeders
+# # --- END DEBUG LINES ---
+
+# Make startup script executable
+COPY start.sh ./start.sh
+RUN chmod +x ./start.sh
+
+# Set default command
+#CMD ["uvicorn", "backend.src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -435,6 +435,46 @@ Tests       7 passed (7)
 - ✅ Backend: 97%+ total coverage
 - ✅ Frontend: 100% patch coverage
 
+# ✅ Day 14 - SkillMate Backend - Docker &  PostgreSQL Setup 
+
+> 💥 After 9 intense hours and 4+ hrs debugging volume issues — we finally have a working Dockerized FastAPI backend using **PostgreSQL** instead of SQLite! This README documents the working state as of **July 24**.
+
+---
+
+## ✅ Achievements
+
+- [x] ✅ Dockerized FastAPI app with `uvicorn`
+- [x] ✅ Switched from SQLite → PostgreSQL
+- [x] ✅ Dockerized PostgreSQL container with volume persistence
+- [x] ✅ Seed DB script runs only once at container startup
+- [x] ✅ `.env` configuration respected inside Docker
+- [x] ✅ Verified API routes accessible at `http://localhost:8000`
+- [x] ✅ Removed faulty volume mount (`.backend:/app/backend`)
+- [x] ✅ Full image rebuild after cache purge (`1.6GB` reclaimed)
+
+---
+
+## 🐘 Database: PostgreSQL via Docker
+
+### 📦 PostgreSQL Service (docker-compose.yml)
+
+```yaml
+services:
+  db:
+    image: postgres:15
+    container_name: skillmate-db
+    restart: always
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: skillmate_user
+      POSTGRES_PASSWORD: supersecret
+      POSTGRES_DB: skillmate_db
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
 
 ## 🧠 Key Learnings
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,8 @@ APP_TITLE="SkillMate API"
 APP_DESCRIPTION="API for SkillMate application"
 APP_VERSION="0.1.0"
 
-DATABASE_URL=
+#DATABASE_URL=sqlite:///backend/skillmate.db
+DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<database>
 
 SECRET_KEY=
 ALGORITHM=

--- a/backend/src/core/config.py
+++ b/backend/src/core/config.py
@@ -31,7 +31,7 @@ class Settings(BaseSettings):
     # DO NOT use env="..." for these if you want to rely on the default mapping
     # and they are truly required with no default value.
     # These are required and will look for DATABASE_URL and SECRET_KEY env vars
-    database_url: str
+    database_url: str = "sqlite:///backend/skillmate.db"
     secret_key: str
 
     algorithm: str = "HS256"

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -4,10 +4,10 @@ from middlewares.logging import LoggingMiddleware
 from routes.index import router
 from core.config import config
 from data.db import init_db
-# import logging
+import logging
 
 app = FastAPI(title=config.app_title,description=config.app_description,version=config.app_version)
-# logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 # Event handler to initialize the database on application startup
 @app.on_event("startup")
 def on_startup():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+    db:
+      image: postgres:16
+      restart: always
+      environment:
+            POSTGRES_USER: skillmate
+            POSTGRES_PASSWORD: supersecret
+            POSTGRES_DB: skillmate_db
+      volumes:
+            - postgres_data:/var/lib/postgresql/data
+      ports:
+            - "5432:5432" 
+    backend:
+      build: 
+        context: .
+        dockerfile: Dockerfile
+      container_name: skillmate-backend
+      #command: sh -c "PYTHONPATH=./backend/src uvicorn main:app --host 0.0.0.0 --port 8000 --reload"
+      # volumes:
+      #   - .backend:/app/backend
+      env_file:
+        - backend/.env.docker
+      ports:
+        - "8000:8000"
+      depends_on:
+        - db
+      #So unless you're intentionally overriding it (e.g., in CI/CD), it’s better to keep a single source of truth:
+      # environment: 
+      #   DATABASE_URL: postgresql+psycopg2://skillmate:supersecret@db:5432/skillmate_db
+      restart: unless-stopped
+volumes:
+  postgres_data:  

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Run DB seed only once
+if [ ! -f "/app/.seeded" ]; then
+    echo "⚙️ Running database seeder..."
+    python ./backend/src/seeders/seed.py
+    touch /app/.seeded
+else
+    echo "Skipping seed, already done."
+fi
+
+# Start the FastAPI server
+PYTHONPATH=./backend/src uvicorn main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
# ✅ Day 14 - SkillMate Backend - Docker &  PostgreSQL Setup 

> 💥 After 9 intense hours and 4+ hrs debugging volume issues — we finally have a working Dockerized FastAPI backend using **PostgreSQL** instead of SQLite! This README documents the working state as of **July 24**.

---

## ✅ Achievements

- [x] ✅ Dockerized FastAPI app with `uvicorn`
- [x] ✅ Switched from SQLite → PostgreSQL
- [x] ✅ Dockerized PostgreSQL container with volume persistence
- [x] ✅ Seed DB script runs only once at container startup
- [x] ✅ `.env` configuration respected inside Docker
- [x] ✅ Verified API routes accessible at `http://localhost:8000`
- [x] ✅ Removed faulty volume mount (`.backend:/app/backend`)
- [x] ✅ Full image rebuild after cache purge (`1.6GB` reclaimed)

---

## 🐘 Database: PostgreSQL via Docker

### 📦 PostgreSQL Service (docker-compose.yml)

```yaml
services:
  db:
    image: postgres:15
    container_name: skillmate-db
    restart: always
    ports:
      - "5432:5432"
    environment:
      POSTGRES_USER: skillmate_user
      POSTGRES_PASSWORD: supersecret
      POSTGRES_DB: skillmate_db
    volumes:
      - pgdata:/var/lib/postgresql/data

volumes:
  pgdata: